### PR TITLE
Updates to extend the core recommendations for 1.2.

### DIFF
--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -108,7 +108,7 @@
               End date
             </th>
             <td>
-              31 January 2026
+              30 March 2026
             </td>
           </tr>
           <tr>
@@ -153,7 +153,11 @@
       <section id="scope" class="scope">
         <h2>Scope</h2>
 				<p>
-					The Working Group will maintain the JSON-LD specifications (i.e., <a href="https://www.w3.org/TR/json-ld11/">JSON-LD 1.1</a>, <a href="https://www.w3.org/TR/json-ld11-api/">JSON-LD 1.1 API</a>, <a href="https://www.w3.org/TR/json-ld11-framing/">JSON-LD 1.1 Framing</a>) that together provide a JSON format for Linked Open Data to interoperate at web-scale, in a method which is familiar to and usable by web-focused software engineers.
+					The Working Group will extend the recommendations defining the JSON-LD specifications (i.e., <a href="https://www.w3.org/TR/json-ld11/">JSON-LD 1.1</a>, <a href="https://www.w3.org/TR/json-ld11-api/">JSON-LD 1.1 API</a>, <a href="https://www.w3.org/TR/json-ld11-framing/">JSON-LD 1.1 Framing</a>)
+          with the features introduced by <a href="https://www.w3.org/TR/rdf12-concepts">RDF-star</a>
+          in addition to open Errata and requested features
+          as noted on the groups <a href="https://github.com/orgs/w3c/projects/84">Project Management Page</a>.
+          These specifications together provide a JSON format for Linked Open Data to interoperate at web-scale, in a method which is familiar to and usable by web-focused software engineers.
 					<!-- Note that the JSON-LD APIs are not browser specific; while appropriate for use within browsers, they are not limited to such use, and there is no requirement for browsers to implement them natively. -->
 				</p>
         <p>
@@ -188,10 +192,10 @@
             Normative Specifications
           </h3>
           <p>
-            The Working Group will maintain the following W3C normative specifications:
+            The Working Group will deliver the following W3C normative specifications specifications:
           </p>
             <dl>
-              <dt><strong>JSON-LD 1.1</strong></dt>
+              <dt><strong>JSON-LD 1.2</strong></dt>
               <dd>
                   Latest publication: 07 May 2020<br>
                   Draft State: W3C Recommendation<br>
@@ -199,7 +203,7 @@
                   Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2020Mar/0005.html">Call for Exclusion</a> 5 March 2020, ended on 4 May 2020<br>
                   Produced under Working Group Charter: <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>
               </dd>
-              <dt><strong>JSON-LD 1.1 Processing Algorithms and API</strong></dt>
+              <dt><strong>JSON-LD 1.2 Processing Algorithms and API</strong></dt>
               <dd>
                   Latest publication: 07 May 2020<br>
                   Draft State: W3C Recommendation<br>
@@ -207,7 +211,7 @@
                   Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2020Mar/0004.html">Call for Exclusion</a> 5 March 2020, ended on 4 May 2020<br>
                   Produced under Working Group Charter: <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>
               </dd>
-              <dt><strong>JSON-LD 1.1 Framing</strong></dt>
+              <dt><strong>JSON-LD 1.2 Framing</strong></dt>
               <dd>
                   Latest publication: 07 May 2020<br>
                   Draft State: W3C Recommendation<br>
@@ -275,6 +279,9 @@
               </li>
               <li>Q2 2025
                 <ul>
+                  <li>FPWD of JSON-LD 1.2</li>
+                  <li>FPWD of JSON-LD 1.2 API</li>
+                  <li>FPWD of JSON-LD 1.2 Framing</li>
                   <li>Candidate Recommendation of CBOR-LD</li>
                   <li>Candidate Recommendation of YAML-LD</li>
                 </ul>
@@ -283,6 +290,20 @@
                 <ul>
                   <li>Recommendation of CBOR-LD</li>
                   <li>Recommendation of YAML-LD</li>
+                </ul>
+              </li>
+              <li>Q4 2025
+                <ul>
+                  <li>Candidate Recommendation of JSON-LD 1.2</li>
+                  <li>Candidate Recommendation of JSON-LD 1.2 API</li>
+                  <li>Candidate Recommendation of JSON-LD 1.2 Framing</li>
+                </ul>
+              </li>
+              <li>Q1 2026
+                <ul>
+                  <li>Recommendation of JSON-LD 1.2</li>
+                  <li>Recommendation of JSON-LD 1.2 API</li>
+                  <li>Recommendation of JSON-LD 1.2 Framing</li>
                 </ul>
               </li>
             </ul>
@@ -533,7 +554,7 @@
 							<tr>
 								<th><a href="">Rechartered <i class=todo>LINK TBD</i></a></th>
 								<td><i class=todo>TBD</i></td>
-								<td><i>31 January 2026</i></td>
+								<td><i>30 March 2026</i></td>
 								<td><i>Add new deliverable</i></td>
 							</tr>
             </tbody>

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -192,7 +192,7 @@
             Normative Specifications
           </h3>
           <p>
-            The Working Group will deliver the following W3C normative specifications specifications:
+            The Working Group will deliver the following W3C normative specifications:
           </p>
             <dl>
               <dt><strong>JSON-LD 1.2</strong></dt>


### PR DESCRIPTION
FPWD dates are out from YAML-LD and CBOR-LD, as is REC dates; those other dates may need to be updated to reference the JSON-LD 1.2 versions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/pull/6.html" title="Last updated on Sep 9, 2024, 5:26 PM UTC (6ee0a66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/6/5bf1096...6ee0a66.html" title="Last updated on Sep 9, 2024, 5:26 PM UTC (6ee0a66)">Diff</a>