### PR TITLE
Rework as the Linked Data Formats WG

### DIFF
--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title>Linked Data Formats Working Group Charter</title>
+    <title>JSON-LD Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -72,12 +72,12 @@
 
 
     <main>
-      <h1 id="title"><i class=todo>DRAFT</i> Linked Data Formats Working Group Charter</h1>
+      <h1 id="title"><i class=todo>DRAFT</i> JSON-LD Working Group Charter</h1>
 
-      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/groups/wg/json-ld">Linked Data Formats Working Group</a> is to extend the <a href="https://www.w3.org/groups/wg/json-ld/publications">family of JSON-LD Recommendations</a> to provide Linked Data expressions in a range of formats and sizes.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/groups/wg/json-ld">JSON-LD Working Group</a> is to maintain and extend the <a href="https://www.w3.org/groups/wg/json-ld/publications">family of JSON-LD 1.1 Recommendations</a> and related Working Group Notes.</p>
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/groups/wg/json-ld/join">Join the Linked Data Formats Working Group.</a></p>
+        <p class="join"><a href="https://www.w3.org/groups/wg/json-ld/join">Join the JSON-LD Working Group.</a></p>
       </div>
 
       <p class=todo style="padding: 0.5ex; border: 1px solid green">
@@ -181,7 +181,7 @@
           It will also develop new Recommendation Track deliverables, based on work incubated by the <a href="https://www.w3.org/community/json-ld/">JSON for Linking Data Community Group</a>,
           specifying the use of JSON-LD algorithms with similar formats (YAML, CBOR, and more).
         </p>
-        <p>The Working group is expected to coordinate with the <a href='https://www.w3.org/community/json-ld/'>JSON for Linking Data Community Group</a> on consensus-based proposals related to content changes for the Linked Data Formats Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</p>
+        <p>The Working group is expected to coordinate with the <a href='https://www.w3.org/community/json-ld/'>JSON for Linking Data Community Group</a> on consensus-based proposals related to content changes for the JSON-LD Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</p>
 
         <section id="section-feature-updates">
           <h3 id="in-scope">In Scope</h3>
@@ -439,7 +439,7 @@
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
             <dt><a href='https://www.w3.org/community/json-ld/'>JSON for Linking Data Community Group</a></dt>
-            <dd>As mentioned in the scope section, the Working group is expected to coordinate with this Community Group on consensus-based proposals related to content changes for the Linked Data Formats Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</dd>
+            <dd>As mentioned in the scope section, the Working group is expected to coordinate with this Community Group on consensus-based proposals related to content changes for the JSON-LD Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</dd>
 
 						<dt><a href="https://www.w3.org/groups/wg/dc">Verifiable Credentials Working Group</a></dt>
 						<dd>Coordination on named graph indexing and other concerns regarding support for normalization and digital signatures.</dd>
@@ -500,10 +500,10 @@
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="">Linked Data Formats Working Group home page.</a>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="">JSON-LD Working Group home page.</a>
         </p>
         <p>
-          Most Linked Data Formats Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+          Most JSON-LD Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
           This group primarily conducts its technical work  on <a id="public-github" href="https://www.w3.org/groups/wg/json-ld/tools">GitHub issues</a>.

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -382,9 +382,6 @@
 						<dt><a href="https://www.w3.org/groups/wg/dc">Verifiable Credentials Working Group</a></dt>
 						<dd>Coordination on named graph indexing and other concerns regarding support for normalization and digital signatures.</dd>
 
-						<dt><a href="https://www.w3.org/groups/wg/rch">RDF Dataset Canonicalization and Hash Working Group</a></dt>
-						<dd>The work of this Group will include defining RDF Dataset Canonicalization algorithms.</dd>
-
             <dt><a href="https://www.w3.org/groups/wg/rdf-star">RDF-Star Working Group</a></dt>
 						<dd>The work of this Group will the ability to concisely represent and query statements about statements.</dd>
 

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -251,7 +251,7 @@
             The Working Group will also deliver the following W3C normative specifications:
           </p>
           <dl>
-              <dt><strong>CBOR-LD</strong></dt>
+              <dt><strong>CBOR-LD 1.0</strong></dt>
               <dd>
                   <p>CBOR is a compact binary data serialization and messaging format. This specification defines CBOR-LD, a CBOR-based format to serialize Linked Data. The encoding is designed to leverage the existing JSON-LD ecosystem, to provide a compact serialization format for those seeking efficient encoding schemes for Linked Data.</p>
                   <p>
@@ -263,16 +263,16 @@
                       Editor's Draft (2022-12-06), adopted from previous JSON-LD Working Group
                     </ul>
                   </div>
-                  <p><b>Expected completion:</b> CR in Q4 2024</p>
+                  <p><b>Expected completion:</b> CR in Q4 2026</p>
               </dd>
-              <dt><strong>YAML-LD</strong></dt>
+              <dt><strong>YAML-LD 1.0</strong></dt>
               <dd>
                   <p>This document defines YAML-LD, a set of conventions built on top of YAML, which outlines how to serialize Linked Data as YAML based on JSON-LD syntax, semantics, and APIs.</p>
                   <p><b>Input document:</b>
                     <a href="https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/">YAML-LD</a>,
                     Final Community Group Report (2023-12-06), adopted from the JSON for Linking Data Community Group
                   </p>
-                  <p><b>Expected completion:</b> CR in Q4 2024</p>
+                  <p><b>Expected completion:</b> CR in Q4 2026</p>
              </dd>
           </dl>
 

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -144,9 +144,26 @@
       <div id="background" class="background">
         <h2>Motivation and Background</h2>
         <p>
-          JSON-LD (JavaScript Object Notation for Linked Data) is a method of encoding linked data using JSON.
-          The encoding is used used mostly for search engine optimization activities but also for applications such as
-          biomedical informatics, and representing provenance information.
+          JSON-LD (JavaScript Object Notation for Linked Data) is a widely used method of encoding Linked Data using JSON.
+          Use of JSON-LD has grown and expanded over the last decade (since it's first publication as a
+          <a href="https://www.w3.org/TR/json-ld-api1/">W3C Recommendation in 2014</a>).
+          JSON-LD remains a popular choice for ecoding <abbr title="Seach Engine Optimization">SEO</abbr>-focused
+          structured data in Web pages. JSON-LD has also become a foundational format for social media (ActivityStreams),
+          Internet of Things data (Web of Things Description), Verifiable Credentials, and Software Bill of Materials (SPDX).
+        </p>
+        <p>This growth in the applied use of JSON-LD has resulted in community interest in additional expressions of
+          JSON-LD's underlying Linked Data expression into other formats. YAML-LD has been created by the
+          <a href="https://www.w3.org/community/json-ld/">JSON for Linking Data Community Group</a> for easing human
+          authoring and providing a clearer path for using Linked Data applied to popular YAML-based documents such as
+          infrastructure as code, static site front matter, and API documentation formats. Additionally, a need has
+          arised in the Verifiable Credentials space for providing a more compressed expression of JSON-LD, and work on
+          CBOR-LD was begun in the JSON-LD CG.
+        </p>
+        <p>
+          The hope of this new more inclusively focused Linked Data Formats WG is to meet the demand of the broader
+          JSON-LD community by strengthening the foundational JSON-LD specifications and aligning it with the latest
+          RDF 1.2 specifications, growing the family of Linked Data formats which orbit around the JSON-LD data model,
+          and specify additional processing and context retrieval methods for greater clarity and stability.
         </p>
       </div>
 

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -174,14 +174,14 @@
           with the features introduced by <a href="https://www.w3.org/TR/rdf12-concepts">RDF-star</a>
           in addition to open Errata and requested features
           as noted on the groups <a href="https://github.com/orgs/w3c/projects/84">Project Management Page</a>.
-          These specifications together provide a JSON format for Linked Open Data to interoperate at web-scale, in a method which is familiar to and usable by web-focused software engineers.
+          These specifications together provide a JSON format for Linked Data to interoperate in a method which is familiar to and usable by software engineers.
 					<!-- Note that the JSON-LD APIs are not browser specific; while appropriate for use within browsers, they are not limited to such use, and there is no requirement for browsers to implement them natively. -->
 				</p>
         <p>
-          It will also develop new Recommendation Track deliverables, based on work incubated by the <a href="https://www.w3.org/community/json-ld/">JSON for Linking Data Community Group</a>,
+          The Working Group will also develop new Recommendation Track deliverables, based on work incubated by the <a href="https://www.w3.org/community/json-ld/">JSON for Linking Data Community Group</a>,
           specifying the use of JSON-LD algorithms with similar formats (YAML, CBOR, and more).
         </p>
-        <p>The Working group is expected to coordinate with the <a href='https://www.w3.org/community/json-ld/'>JSON for Linking Data Community Group</a> on consensus-based proposals related to content changes for the JSON-LD Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</p>
+        <p>The Working Group is expected to coordinate with the <a href='https://www.w3.org/community/json-ld/'>JSON for Linking Data Community Group</a> on consensus-based proposals related to content changes for the JSON-LD Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</p>
 
         <section id="section-feature-updates">
           <h3 id="in-scope">In Scope</h3>

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -289,8 +289,7 @@
             <ul>
               <li>Application profile of JSON-LD to enable efficient streaming parsers.</li>
               <li>Test suites and implementation reports for the specifications.</li>
-              <li>Best practices for use and implementation of JSON-LD 1.1.</li>
-              <li>Best practices for supporting multiple languages in JSON, based on JSON-LD <a href="https://www.w3.org/TR/json-ld/#value-objects">value objects</a></li>
+              <li>Best practices for use and implementation of JSON-LD 1.1 and 1.2.</li>
             </ul>
         </section>
 

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -185,73 +185,12 @@
 
         <section id="section-feature-updates">
           <h3 id="in-scope">In Scope</h3>
-            <p>In addition to Errata and synchronization with the RDF-star Working Group, the following features tracked on the
+            <p>In addition to Errata and synchronization with the RDF-star Working Group, features tracked on the
               <a href="https://github.com/orgs/w3c/projects/84">Project Management Page</a>
-              are in-scope for updates to the core JSON-LD specifications:</p>
-
-            <ul class="scope">
-              <li>Additional updates to properly abstract serialization/deserialization based on content type
-                (PR <a href="https://github.com/w3c/json-ld-api/pull/608">w3c/json-ld-api#608</a>).</li>
-              <li>Address concerns from Verifiable Credentials
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/422">w3c/json-ld-syntax#422</a>).</li>
-              <li>Allow class-scoped framing
-                (issue <a href="https://github.com/w3c/json-ld-framing/issues/29">w3cjson-ld-framing#29</a>).</li>
-              <li>Allow custom datatypes on JSON Literals
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/425">w3c/json-ld-syntax#425</a>).</li>
-              <li>Change IANA Considerations to make the profile parameter required
-                (PR <a href="https://github.com/w3c/json-ld-framing/pull/154">w3c/json-ld-framing#154</a>).</li>
-              <li>Clarify that lexicographical order uses code point ordering
-                (PR <a href="https://github.com/w3c/json-ld-syntax/pull/417">w3c/json-ld-syntax#417</a>),
-                (PR <a href="https://github.com/w3c/json-ld-api/pull/574">w3c/json-ld-api#574</a>),
-                (PR <a href="https://github.com/w3c/json-ld-framing/pull/153">w3c/json-ld-framing#153</a>).</li>
-              <li>Compact IRI expansion support for non-trivial prefix term definitions
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/191">w3c/json-ld-syntax#191</a>).</li>
-              <li>Compacting native values
-                (issue <a href="https://github.com/w3c/json-ld-api/issues/545">w3c/json-ld-api#545</a>).</li>
-              <li>Consider context by reference with metadata
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/108">w3c/json-ld-syntax#108</a>).</li>
-              <li>Consider <code>@prefix</code>
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/329">w3c/json-ld-syntax#329</a>).</li>
-              <li>Consistent treatment of JSON Literals
-                (issue <a href="https://github.com/w3c/json-ld-api/issues/613">w3c/json-ld-api#613</a>),
-                (PR <a href="https://github.com/w3c/json-ld-api/pull/559">w3c/json-ld-api#599</a>).</li>
-              <li><code>@default</code> in <code>@context</code>
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/328">w3c-json-ld-syntax#328</a>).</li>
-              <li>Expansion does not take property-scoped contexts for nested properties into account
-                (issue <a href="https://github.com/w3c/json-ld-api/issues/380">w3c/json-ld-api#380</a>).</li>
-              <li>Fix context processing for reverse terms(issue <a href=""></a>).</li>
-              <li>Fix context processing for reverse terms
-                (PR <a href="https://github.com/w3c/json-ld-api/pull/566">w3c/json-ld-api#566</a>).</li>
-              <li>Framing nexted graphs
-                (issue <a href="https://github.com/w3c/json-ld-framing/issues/150">w3c/json-ld-framing#150</a>).</li>
-              <li>Graph-aliased keywords don't work as containers
-                (issue <a href="https://github.com/w3c/json-ld-api/issues/536">w3c/json-ld-api#536</a>).</li>
-              <li>Integer JSON value should be able to expand to IRI
-                (issue <a href="https://github.com/w3c/json-ld-api/issues/509">w3c/json-ld-api#509</a>).</li>
-              <li>Language map with global context
-                (issue <a href="https://github.com/w3c/json-ld-framing/issues/126">w3c/json-ld-framing#126</a>).</li>
-              <li>Language-maps don't allow separate base direction
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/280">w3c/json-ld-syntax#280</a>).</li>
-              <li>Lists, sets, and multisets
-                (issue <a href="https://github.com/w3c/json-ld-api/issues/473">w3c/json-ld-api#473</a>).</li>
-              <li>Make it easier to keep semantics of object-oriented models
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/376">w3c/json-ld-syntax#376</a>).</li>
-              <li>Nested properties and compaction
-                (issue <a href="https://github.com/w3c/json-ld-api/issues/391">w3c/json-ld-api#391</a>).</li>
-              <li>Pattern Matching
-                (issue <a href="https://github.com/w3c/json-ld-framing/issues/118">w3c/json-ld-framing#118</a>).</li>
-              <li>Reframing Relationships
-                (issue <a href="https://github.com/w3c/json-ld-framing/issues/73">w3c/json-ld-framing#73</a>).</li>
-              <li>Several frames in the same frame document
-                (issue <a href="https://github.com/w3c/json-ld-framing/issues/38">w3c/json-ld-framing#38</a>).</li>
-              <li>Specify a node type when interpreting JSON as JSON-LD
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/386">w3c/json-ld-syntax#386</a>).</li>
-              <li>Support multiple IRIs for <code>@reverse</code>
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/372">w3c/json-ld-syntax#372</a>).</li>
-              <li>Type Coercion / Node Conversion: <code>@coerce</code> keyword or similar
-                (issue <a href="https://github.com/w3c/json-ld-syntax/issues/335">w3c/json-ld-syntax#335</a>).</li>
-              <li>Miscellaneous test improvements.</li>
-              </ul>
+              are in-scope for updates to the core JSON-LD specifications.</p>
+            <p>The Working Group will also consider <a href="https://www.w3.org/2021/Process-20211102/#allow-new-features">allowing new features</a> in
+              these recommendations, according to <a href="https://www.w3.org/2021/Process-20211102/#revised-rec-features">Section 6.3.11.4 of the W3C
+              process</a>, in order to render future evolutions easier.</p>
         </section>
 
         <section id="section-out-of-scope">

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -388,20 +388,11 @@
             <dt><a href="https://www.w3.org/community/credentials/">Credentials Community Group</a></dt>
 						<dd>Coordination on various concerns regarding the usage of JSON-LD in Verifiable Credentials.</dd>
 
-						<dt><a href="https://www.w3.org/community/schemaorg/">Schema.org Community Group</a></dt>
-						<dd>The Schema.org CG will be regularly solicited for reviews and comments throughout the advancement of the JSON-LD 1.1 Recommendation.</dd>
-
-						<dt><a href="https://www.w3.org/groups/wg/did">Decentralized Identifiers Working Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/wg/did">Decentralized Identifiers Working Group</a></dt>
 						<dd>Coordination on various concerns regarding the JSON-LD encoding of DID Documents.</dd>
 
 						<dt><a href="https://www.w3.org/groups/wg/wot">Web of Things Working Group</a></dt>
 						<dd>Coordination of various topics concerning the use of JSON-LD by the WoT Thing Description.</dd>
-
-            <dt><a href="https://www.w3.org/community/rdf-dev/">RDF-DEV CG</a></dt>
-						<dd>Coordination on various aspects of future RDF core specifications.</dd>
-
-						<dt><a href="https://www.w3.org/community/rdfjs/">RDF JavaScript Libraries CG</a></dt>
-						<dd>Coordination on various opportunities for JSON-LD support in RDF.js related libraries and community projects.</dd>
 
           </dl>
         </section>

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -171,7 +171,7 @@
         <h2>Scope</h2>
 				<p>
 					The Working Group will extend the recommendations defining the JSON-LD specifications (i.e., <a href="https://www.w3.org/TR/json-ld11/">JSON-LD 1.1</a>, <a href="https://www.w3.org/TR/json-ld11-api/">JSON-LD 1.1 API</a>, <a href="https://www.w3.org/TR/json-ld11-framing/">JSON-LD 1.1 Framing</a>)
-          with the features introduced by <a href="https://www.w3.org/TR/rdf12-concepts">RDF-star</a>
+          with the features introduced by <a href="https://www.w3.org/TR/rdf12-concepts">RDF 1.2</a>
           in addition to open Errata and requested features
           as noted on the groups <a href="https://github.com/orgs/w3c/projects/84">Project Management Page</a>.
           These specifications together provide a JSON format for Linked Data to interoperate in a method which is familiar to and usable by software engineers.
@@ -185,7 +185,7 @@
 
         <section id="section-feature-updates">
           <h3 id="in-scope">In Scope</h3>
-            <p>In addition to Errata and synchronization with the RDF-star Working Group, features tracked on the
+            <p>In addition to Errata and synchronization with the RDF & SPARQL Working Group, features tracked on the
               <a href="https://github.com/orgs/w3c/projects/84">Project Management Page</a>
               are in-scope for updates to the core JSON-LD specifications.</p>
             <p>The Working Group will also consider <a href="https://www.w3.org/2021/Process-20211102/#allow-new-features">allowing new features</a> in
@@ -382,7 +382,7 @@
 						<dt><a href="https://www.w3.org/groups/wg/dc">Verifiable Credentials Working Group</a></dt>
 						<dd>Coordination on named graph indexing and other concerns regarding support for normalization and digital signatures.</dd>
 
-            <dt><a href="https://www.w3.org/groups/wg/rdf-star">RDF-Star Working Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/wg/rdf-star">RDF & SPARQL Working Group</a></dt>
 						<dd>The work of this Group will the ability to concisely represent and query statements about statements.</dd>
 
             <dt><a href="https://www.w3.org/community/credentials/">Credentials Community Group</a></dt>

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -379,20 +379,20 @@
             <dt><a href='https://www.w3.org/community/json-ld/'>JSON for Linking Data Community Group</a></dt>
             <dd>As mentioned in the scope section, the Working group is expected to coordinate with this Community Group on consensus-based proposals related to content changes for the JSON-LD Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</dd>
 
-						<dt><a href="https://www.w3.org/groups/wg/dc">Verifiable Credentials Working Group</a></dt>
-						<dd>Coordination on named graph indexing and other concerns regarding support for normalization and digital signatures.</dd>
-
             <dt><a href="https://www.w3.org/groups/wg/rdf-star">RDF & SPARQL Working Group</a></dt>
 						<dd>The work of this Group will the ability to concisely represent and query statements about statements.</dd>
 
-            <dt><a href="https://www.w3.org/community/credentials/">Credentials Community Group</a></dt>
-						<dd>Coordination on various concerns regarding the usage of JSON-LD in Verifiable Credentials.</dd>
+						<dt><a href="https://www.w3.org/groups/wg/dc">Verifiable Credentials Working Group</a></dt>
+						<dd>Coordination on named graph indexing and other concerns regarding support for normalization and digital signatures.</dd>
 
             <dt><a href="https://www.w3.org/groups/wg/did">Decentralized Identifiers Working Group</a></dt>
 						<dd>Coordination on various concerns regarding the JSON-LD encoding of DID Documents.</dd>
 
 						<dt><a href="https://www.w3.org/groups/wg/wot">Web of Things Working Group</a></dt>
 						<dd>Coordination of various topics concerning the use of JSON-LD by the WoT Thing Description.</dd>
+
+            <dt><a href="https://www.w3.org/community/credentials/">Credentials Community Group</a></dt>
+						<dd>Coordination on various concerns regarding the usage of JSON-LD in Verifiable Credentials.</dd>
 
           </dl>
         </section>

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -296,14 +296,14 @@
         <section id="timeline">
           <h3>Timeline</h3>
             <ul>
-              <li>September 2022: First teleconference</li>
-              <li>Q4 2024
+              <li>November 2025: First teleconference</li>
+              <li>Q2 2026
                 <ul>
                   <li>FPWD of CBOR-LD</li>
                   <li>FPWD of YAML-LD</li>
                 </ul>
               </li>
-              <li>Q2 2025
+              <li>Q4 2026
                 <ul>
                   <li>FPWD of JSON-LD 1.2</li>
                   <li>FPWD of JSON-LD 1.2 API</li>
@@ -312,20 +312,20 @@
                   <li>Candidate Recommendation of YAML-LD</li>
                 </ul>
               </li>
-              <li>Q3 2025
+              <li>Q1 2027
                 <ul>
                   <li>Recommendation of CBOR-LD</li>
                   <li>Recommendation of YAML-LD</li>
                 </ul>
               </li>
-              <li>Q4 2025
+              <li>Q3 2027
                 <ul>
                   <li>Candidate Recommendation of JSON-LD 1.2</li>
                   <li>Candidate Recommendation of JSON-LD 1.2 API</li>
                   <li>Candidate Recommendation of JSON-LD 1.2 Framing</li>
                 </ul>
               </li>
-              <li>Q1 2026
+              <li>Q4 2027
                 <ul>
                   <li>Recommendation of JSON-LD 1.2</li>
                   <li>Recommendation of JSON-LD 1.2 API</li>

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -152,7 +152,7 @@
           Internet of Things data (Web of Things Description), Verifiable Credentials, and Software Bill of Materials (SPDX).
         </p>
         <p>This growth in the applied use of JSON-LD has resulted in community interest in additional expressions of
-          JSON-LD's underlying Linked Data expression into other formats. YAML-LD has been created by the
+          JSON-LD's underlying Linked Data structure into other formats. YAML-LD has been created by the
           <a href="https://www.w3.org/community/json-ld/">JSON for Linking Data Community Group</a> for easing human
           authoring and providing a clearer path for using Linked Data applied to popular YAML-based documents such as
           infrastructure as code, static site front matter, and API documentation formats. Additionally, a need has

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title>JSON-LD Working Group Charter</title>
+    <title>Linked Data Formats Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -72,12 +72,12 @@
 
 
     <main>
-      <h1 id="title"><i class=todo>DRAFT</i> JSON-LD Working Group Charter</h1>
+      <h1 id="title"><i class=todo>DRAFT</i> Linked Data Formats Working Group Charter</h1>
 
-      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/groups/wg/json-ld">JSON-LD Working Group</a> is to maintain and extend the <a href="https://www.w3.org/groups/wg/json-ld/publications">family of JSON-LD 1.1 Recommendations</a> and related Working Group Notes.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/groups/wg/json-ld">Linked Data Formats Working Group</a> is to extend the <a href="https://www.w3.org/groups/wg/json-ld/publications">family of JSON-LD Recommendations</a> to provide Linked Data expressions in a range of formats and sizes.</p>
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/groups/wg/json-ld/join">Join the JSON-LD Working Group.</a></p>
+        <p class="join"><a href="https://www.w3.org/groups/wg/json-ld/join">Join the Linked Data Formats Working Group.</a></p>
       </div>
 
       <p class=todo style="padding: 0.5ex; border: 1px solid green">
@@ -164,7 +164,7 @@
           It will also develop new Recommendation Track deliverables, based on work incubated by the <a href="https://www.w3.org/community/json-ld/">JSON for Linking Data Community Group</a>,
           specifying the use of JSON-LD algorithms with similar formats (YAML, CBOR, and more).
         </p>
-        <p>The Working group is expected to coordinate with the <a href='https://www.w3.org/community/json-ld/'>JSON for Linking Data Community Group</a> on consensus-based proposals related to content changes for the JSON-LD Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</p>
+        <p>The Working group is expected to coordinate with the <a href='https://www.w3.org/community/json-ld/'>JSON for Linking Data Community Group</a> on consensus-based proposals related to content changes for the Linked Data Formats Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</p>
 
         <section id="section-feature-updates">
           <h3 id="in-scope">In Scope</h3>
@@ -422,7 +422,7 @@
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
             <dt><a href='https://www.w3.org/community/json-ld/'>JSON for Linking Data Community Group</a></dt>
-            <dd>As mentioned in the scope section, the Working group is expected to coordinate with this Community Group on consensus-based proposals related to content changes for the JSON-LD Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</dd>
+            <dd>As mentioned in the scope section, the Working group is expected to coordinate with this Community Group on consensus-based proposals related to content changes for the Linked Data Formats Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</dd>
 
 						<dt><a href="https://www.w3.org/groups/wg/dc">Verifiable Credentials Working Group</a></dt>
 						<dd>Coordination on named graph indexing and other concerns regarding support for normalization and digital signatures.</dd>
@@ -483,10 +483,10 @@
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="">JSON-LD Working Group home page.</a>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="">Linked Data Formats Working Group home page.</a>
         </p>
         <p>
-          Most JSON-LD Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+          Most Linked Data Formats Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
           This group primarily conducts its technical work  on <a id="public-github" href="https://www.w3.org/groups/wg/json-ld/tools">GitHub issues</a>.

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -224,25 +224,25 @@
             <dl>
               <dt><strong>JSON-LD 1.2</strong></dt>
               <dd>
-                  Latest publication: 07 May 2020<br>
                   Draft State: W3C Recommendation<br>
                   Reference Draft: <a href="https://www.w3.org/TR/2020/REC-json-ld11-20200716/">https://www.w3.org/TR/2020/REC-json-ld11-20200716/</a><br>
+                  Latest publication: 07 May 2020<br>
                   Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2020Mar/0005.html">Call for Exclusion</a> 5 March 2020, ended on 4 May 2020<br>
                   Produced under Working Group Charter: <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>
               </dd>
               <dt><strong>JSON-LD 1.2 Processing Algorithms and API</strong></dt>
               <dd>
-                  Latest publication: 07 May 2020<br>
                   Draft State: W3C Recommendation<br>
                   Reference Draft: <a href="https://www.w3.org/TR/2020/REC-json-ld11-api-20200716/">https://www.w3.org/TR/2020/REC-json-ld11-api-20200716/</a><br>
+                  Latest publication: 07 May 2020<br>
                   Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2020Mar/0004.html">Call for Exclusion</a> 5 March 2020, ended on 4 May 2020<br>
                   Produced under Working Group Charter: <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>
               </dd>
               <dt><strong>JSON-LD 1.2 Framing</strong></dt>
               <dd>
-                  Latest publication: 07 May 2020<br>
                   Draft State: W3C Recommendation<br>
                   Reference Draft: <a href="https://www.w3.org/TR/2020/REC-json-ld11-framing-20200716/">https://www.w3.org/TR/2020/REC-json-ld11-framing-20200716/</a><br>
+                  Latest publication: 07 May 2020<br>
                   Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2019Dec/0003.html">Call for Exclusion</a> 12 December 2019, ended on 10 February 2020<br>
                   Produced under Working Group Charter: <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>
               </dd>

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -160,10 +160,10 @@
           CBOR-LD was begun in the JSON-LD CG.
         </p>
         <p>
-          The hope of this new more inclusively focused Linked Data Formats WG is to meet the demand of the broader
+          The hope of this new more inclusively focused JSON-LD WG is to meet the demand of the broader
           JSON-LD community by strengthening the foundational JSON-LD specifications and aligning it with the latest
-          RDF 1.2 specifications, growing the family of Linked Data formats which orbit around the JSON-LD data model,
-          and specify additional processing and context retrieval methods for greater clarity and stability.
+          RDF 1.2 specifications, growing the family of JSON-LD related formats which orbit around the JSON-LD
+          processing model, and specifing improved context retrieval methods for greater clarity and stability.
         </p>
       </div>
 


### PR DESCRIPTION
This is an early stage reworking of the charter to try to address the group's interest in a more inclusive name indicative of our interest in publishing YAML-LD and CBOR-LD alongside a new/updated JSON-LD.

Much more editing to do, but I wanted to share this early to get feedback.

Cheers!
🎩


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/pull/10.html" title="Last updated on Aug 13, 2025, 4:31 PM UTC (da62ffc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/10/d155365...da62ffc.html" title="Last updated on Aug 13, 2025, 4:31 PM UTC (da62ffc)">Diff</a>