### PR TITLE
Sync the charter text with the latest charter template

### DIFF
--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -153,8 +153,11 @@
           Use of JSON-LD has grown and expanded over the last decade (since it's first publication as a
           <a href="https://www.w3.org/TR/json-ld-api1/">W3C Recommendation in 2014</a>).
           JSON-LD remains a popular choice for encoding <abbr title="Seach Engine Optimization">SEO</abbr>-focused
-          structured data in Web pages. JSON-LD has also become a foundational format for social media (ActivityStreams),
-          Internet of Things data (Web of Things Description), Verifiable Credentials, and Software Bill of Materials (SPDX).
+          structured data in Web pages. JSON-LD has also become a foundational format for social media
+          (<a href="https://www.w3.org/TR/activitystreams-core/">ActivityStreams</a>),
+          Internet of Things data (<a href="https://www.w3.org/TR/wot-thing-description11/">Web of Things Description</a>),
+          <a href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials</a>, and Software Bill of Materials
+          (<a href="https://spdx.github.io/spdx-spec/v3.0.1/serializations/#serialization-in-json-ld">SPDX</a>).
         </p>
         <p>This growth in the applied use of JSON-LD has resulted in community interest in additional expressions of
           JSON-LD's underlying Linked Data structure in other formats. YAML-LD has been created by the

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -55,7 +55,7 @@
           <li><a href="#background">Background</a></li>
           <li><a href="#scope">Scope</a></li>
           <li><a href="#deliverables">Deliverables</a></li>
-		      <li><a href="#success-criteria">Success Criteria</a></li>
+          <li><a href="#success-criteria">Success Criteria</a></li>
           <li><a href="#coordination">Coordination</a></li>
           <li><a href="#participation">Participation</a></li>
           <li><a href="#communication">Communication</a></li>

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -152,23 +152,23 @@
           JSON-LD (JavaScript Object Notation for Linked Data) is a widely used method of encoding Linked Data using JSON.
           Use of JSON-LD has grown and expanded over the last decade (since it's first publication as a
           <a href="https://www.w3.org/TR/json-ld-api1/">W3C Recommendation in 2014</a>).
-          JSON-LD remains a popular choice for ecoding <abbr title="Seach Engine Optimization">SEO</abbr>-focused
+          JSON-LD remains a popular choice for encoding <abbr title="Seach Engine Optimization">SEO</abbr>-focused
           structured data in Web pages. JSON-LD has also become a foundational format for social media (ActivityStreams),
           Internet of Things data (Web of Things Description), Verifiable Credentials, and Software Bill of Materials (SPDX).
         </p>
         <p>This growth in the applied use of JSON-LD has resulted in community interest in additional expressions of
-          JSON-LD's underlying Linked Data structure into other formats. YAML-LD has been created by the
+          JSON-LD's underlying Linked Data structure in other formats. YAML-LD has been created by the
           <a href="https://www.w3.org/community/json-ld/">JSON for Linking Data Community Group</a> for easing human
           authoring and providing a clearer path for using Linked Data applied to popular YAML-based documents such as
-          infrastructure as code, static site front matter, and API documentation formats. Additionally, a need has
-          arised in the Verifiable Credentials space for providing a more compressed expression of JSON-LD, and work on
+          infrastructure as code, static site front matter, and API documentation formats. Additionally, a need arose
+          in the Verifiable Credentials space for providing a more compressed expression of JSON-LD, and work on
           CBOR-LD was begun in the JSON-LD CG.
         </p>
         <p>
-          The hope of this new more inclusively focused JSON-LD WG is to meet the demand of the broader
-          JSON-LD community by strengthening the foundational JSON-LD specifications and aligning it with the latest
+          The goal of this new more inclusively focused JSON-LD WG is to meet the demand of the broader
+          JSON-LD community by strengthening the foundational JSON-LD specifications and aligning them with the latest
           RDF 1.2 specifications, growing the family of JSON-LD related formats which orbit around the JSON-LD
-          processing model, and specifing improved context retrieval methods for greater clarity and stability.
+          processing model, and specifying improved context retrieval methods for greater clarity and stability.
         </p>
       </div>
 
@@ -179,7 +179,8 @@
           with the features introduced by <a href="https://www.w3.org/TR/rdf12-concepts">RDF 1.2</a>
           in addition to open Errata and requested features
           as noted on the groups <a href="https://github.com/orgs/w3c/projects/84">Project Management Page</a>.
-          These specifications together provide a JSON format for Linked Data to interoperate in a method which is familiar to and usable by software engineers.
+          Together, these specifications provide a JSON format for Linked Data,
+          enabling interoperation in a way which is familiar to and usable by software engineers.
 					<!-- Note that the JSON-LD APIs are not browser specific; while appropriate for use within browsers, they are not limited to such use, and there is no requirement for browsers to implement them natively. -->
 				</p>
         <p>

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -55,7 +55,7 @@
           <li><a href="#background">Background</a></li>
           <li><a href="#scope">Scope</a></li>
           <li><a href="#deliverables">Deliverables</a></li>
-		  <li><a href="#success-criteria">Success Criteria</a></li>
+		      <li><a href="#success-criteria">Success Criteria</a></li>
           <li><a href="#coordination">Coordination</a></li>
           <li><a href="#participation">Participation</a></li>
           <li><a href="#communication">Communication</a></li>
@@ -73,6 +73,8 @@
 
     <main>
       <h1 id="title"><i class=todo>DRAFT</i> JSON-LD Working Group Charter</h1>
+      <!-- replace DRAFT with PROPOSED when the AC review starts -->
+      <!-- delete PROPOSED after AC review completed -->
 
       <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/groups/wg/json-ld">JSON-LD Working Group</a> is to maintain and extend the <a href="https://www.w3.org/groups/wg/json-ld/publications">family of JSON-LD 1.1 Recommendations</a> and related Working Group Notes.</p>
 
@@ -80,8 +82,11 @@
         <p class="join"><a href="https://www.w3.org/groups/wg/json-ld/join">Join the JSON-LD Working Group.</a></p>
       </div>
 
+      <!-- replace "draft charter" with "proposed charter" when the AC review starts -->
+      <!-- replace GitHub link and issues link to the specific charter in GH and its issues repo -->
+      <!-- delete the GH link after AC review completed -->
       <p class=todo style="padding: 0.5ex; border: 1px solid green">
-        This proposed charter is available on <a href="https://github.com/json-ld/json-ld-wg-charter">GitHub</a>.
+        This draft charter is available on <a href="https://github.com/json-ld/json-ld-wg-charter">GitHub</a>.
         Feel free to raise <a href="https://github.com/json-ld/json-ld-wg-charter/issues">issues</a>.
       </p>
 
@@ -212,7 +217,8 @@
 
         <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/json-ld/publications">group publication status page</a>.</p>
 
-        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval.</p>
+        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval.
+        <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
 
         <section id="normative">
           <h3>
@@ -340,8 +346,11 @@
 	<section id="success-criteria">
 	  <h2>Success Criteria</h2>
 
-	  <p>In order to advance to <a href="https://www.w3.org/policies/process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/policies/process/#implementation-experience">at least two independent interoperable implementations</a> of every feature defined in the specification, where interoperability can be verified by passing open test suites.</p>
+	  <p>In order to advance beyond
+		  <a href="https://www.w3.org/policies/process/#RecsCR" title="Candidate Recommendation">Candidate Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/policies/process/#implementation-experience">at least two independent interoperable implementations</a> of every feature defined in the specification, where interoperability can be verified by passing open test suites. In order to advance beyond Candidate Recommendation, each normative specification must have an open test suite of every feature defined in the specification.</p>
+
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
+
     <p>To promote interoperability, all changes made to specifications
       in Candidate Recommendation
       or to features that have deployed implementations
@@ -352,10 +361,13 @@
 
 	  <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
 
-    <!-- Design principles -->
-    <p>This Working Group expects to follow the
-    TAG <a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.
-    </p>
+    <!-- W3C Statements and Web Platform Design Principles -->
+    <p>This group is expected to be guided by the following documents:</p>
+    <ul>
+      <li><a href="https://www.w3.org/TR/ethical-web-principles/">Ethical Web Principles</a>,</li>
+      <li><a href="https://www.w3.org/TR/privacy-principles/">Privacy Principles</a>,</li>
+      <li><a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.</li>
+    </ul>
 
 	</section>
 
@@ -407,10 +419,13 @@
         </p>
         <p>
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
-        </p>
-        <p>
           The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
         </p>
+
+        <p>
+          The Chairs should periodically look through the non-Members who have contributed to the Working Group or the JSON for Linking Data Community Group and consider whether each one should be invited to participate as an <a href="https://www.w3.org/invited-experts/">Invited Expert</a>. If a non-Member contributor would like to participate in meetings, they are encouraged to <i class="todo">[update this link] <a href="https://www.w3.org/groups/wg/TODO/instructions/">apply to be an Invited Expert</a></i>.
+        </p>
+
         <p>Participants in the group are required (by the <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>) to follow the
           W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Ethics and Professional Conduct</a>.</p>
       </section>
@@ -426,7 +441,7 @@
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="">JSON-LD Working Group home page.</a>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/groups/wg/json-ld">JSON-LD Working Group home page.</a>
         </p>
         <p>
           Most JSON-LD Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.

--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -228,61 +228,69 @@
             The Working Group will deliver the following W3C normative specifications:
           </p>
             <dl>
-              <dt><strong>JSON-LD 1.2</strong></dt>
-              <dd>
-                  Draft State: W3C Recommendation<br>
-                  Reference Draft: <a href="https://www.w3.org/TR/2020/REC-json-ld11-20200716/">https://www.w3.org/TR/2020/REC-json-ld11-20200716/</a><br>
-                  Latest publication: 07 May 2020<br>
-                  Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2020Mar/0005.html">Call for Exclusion</a> 5 March 2020, ended on 4 May 2020<br>
-                  Produced under Working Group Charter: <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>
-              </dd>
-              <dt><strong>JSON-LD 1.2 Processing Algorithms and API</strong></dt>
-              <dd>
-                  Draft State: W3C Recommendation<br>
-                  Reference Draft: <a href="https://www.w3.org/TR/2020/REC-json-ld11-api-20200716/">https://www.w3.org/TR/2020/REC-json-ld11-api-20200716/</a><br>
-                  Latest publication: 07 May 2020<br>
-                  Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2020Mar/0004.html">Call for Exclusion</a> 5 March 2020, ended on 4 May 2020<br>
-                  Produced under Working Group Charter: <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>
-              </dd>
-              <dt><strong>JSON-LD 1.2 Framing</strong></dt>
-              <dd>
-                  Draft State: W3C Recommendation<br>
-                  Reference Draft: <a href="https://www.w3.org/TR/2020/REC-json-ld11-framing-20200716/">https://www.w3.org/TR/2020/REC-json-ld11-framing-20200716/</a><br>
-                  Latest publication: 07 May 2020<br>
-                  Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2019Dec/0003.html">Call for Exclusion</a> 12 December 2019, ended on 10 February 2020<br>
-                  Produced under Working Group Charter: <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>
-              </dd>
-          </dl>
-          <p>
-            The Working Group will also deliver the following W3C normative specifications:
-          </p>
-          <dl>
-              <dt><strong>CBOR-LD 1.0</strong></dt>
-              <dd>
-                  <p>CBOR is a compact binary data serialization and messaging format. This specification defines CBOR-LD, a CBOR-based format to serialize Linked Data. The encoding is designed to leverage the existing JSON-LD ecosystem, to provide a compact serialization format for those seeking efficient encoding schemes for Linked Data.</p>
-                  <p>
-                  <div><b>Input documents:</b>
-                    <ul>
-                      <li><a href="https://json-ld.github.io/cbor-ld-spec/">CBOR-LD</a>,
-                      <i class=todo>Final Community Group Report</i> (<i class=todo>2024-xx-xx</i>), adopted from the JSON for Linking Data Community Group
-                      <li><a href="https://w3c.github.io/json-ld-cbor/">JSON-LD 1.1. in CBOR</a>,
-                      Editor's Draft (2022-12-06), adopted from previous JSON-LD Working Group
-                    </ul>
-                  </div>
-                  <p><b>Expected completion:</b> CR in Q4 2026</p>
-              </dd>
-              <dt><strong>YAML-LD 1.0</strong></dt>
-              <dd>
-                  <p>This document defines YAML-LD, a set of conventions built on top of YAML, which outlines how to serialize Linked Data as YAML based on JSON-LD syntax, semantics, and APIs.</p>
-                  <p><b>Input document:</b>
-                    <a href="https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/">YAML-LD</a>,
-                    Final Community Group Report (2023-12-06), adopted from the JSON for Linking Data Community Group
-                  </p>
-                  <p><b>Expected completion:</b> CR in Q4 2026</p>
-             </dd>
-          </dl>
+            <dt id="json-ld-12" class="spec">JSON-LD 1.2</dt>
+            <dd>
+              <p>This specification will define a new version of JSON-LD, fully compatible with <a href="https://www.w3.org/TR/rdf12-concepts">RDF 1.2</a>.</p>
+
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/TR/json-ld11">Adopted from JSON-LD 1.1 Recommendation</a>.</p>
+
+              <p class="milestone"><b>Expected completion:</b> Q4 2027.</p>
+
+              <p><b>Adopted Draft:</b> JSON-LD 1.1, <a href="https://www.w3.org/TR/2020/REC-json-ld11-20200716/">https://www.w3.org/TR/2020/REC-json-ld11-20200716/</a>, 16 July 2020.</p> 
+
+              <p><b>Exclusion Draft:</b> JSON-LD 1,1, <a href="https://www.w3.org/TR/2020/CR-json-ld11-20200305/">https://www.w3.org/TR/2020/CR-json-ld11-20200305/</a>, 5 March 2020. Exclusion period <b>2020-03-05</b>; Exclusion period <b>2020-05-04</b>.</p>
+
+              <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>.</p>                
+            </dd>
+
+            <dt id="json-ld-api-12" class="spec">JSON-LD 1.2 Processing Algorithms and API</dt>
+            <dd>
+              <p>This specification will define new version of JSON-LD Processing Algorithms and API, fully compatible with <a href="https://www.w3.org/TR/rdf12-concepts">RDF 1.2</a>.</p>
+
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/json-ld11-api/">Adopted from JSON-LD 1.1 Processing Algorithms and API Recommendation</a>.</p>
+              
+              <p class="milestone"><b>Expected completion:</b> Q4 2027.</p>
+
+              <p><b>Adopted Draft:</b> JSON-LD 1.1, <a href="https://www.w3.org/TR/2020/REC-json-ld11-api-20200716/">https://www.w3.org/TR/2020/REC-json-ld11-api-20200716/</a>, 16 July 2020.</p> 
+
+              <p><b>Exclusion Draft:</b> JSON-LD 1,1, <a href="https://www.w3.org/TR/2020/CR-json-ld11-api-20200305/">https://www.w3.org/TR/2020/CR-json-ld11-api-20200305/</a>, 5 March 2020. Exclusion period <b>2020-03-05</b>; Exclusion period <b>2020-05-04</b>.</p>
+
+              <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>.</p>                
+            </dd>
 
 
+            <dt id="json-ld-framing-12" class="spec">JSON-LD 1.2 Framing</dt>
+            <dd>
+              <p>This specification will define new version of JSON-LD Framing, fully compatible with <a href="https://www.w3.org/TR/rdf12-concepts">RDF 1.2</a>.</p>
+
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/json-ld11-framing/">Adopted from JSON-LD 1.1 Framing Recommendation</a>.</p>
+              
+              <p class="milestone"><b>Expected completion:</b> Q4 2027.</p>
+
+              <p><b>Adopted Draft:</b> JSON-LD 1.1, <a href="https://www.w3.org/TR/2020/REC-json-ld11-framing-20200716/">https://www.w3.org/TR/2020/REC-json-ld11-framing-20200716/</a>, 16 July 2020.</p> 
+
+              <p><b>Exclusion Draft:</b> JSON-LD 1,1, <a href="https://www.w3.org/TR/2020/CR-json-ld11-framing-20200305/">https://www.w3.org/TR/2020/CR-json-ld11-framing-20200305/</a>, 5 March 2020. Exclusion period <b>2020-03-05</b>; Exclusion period <b>2020-05-04</b>.</p>
+
+              <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">https://www.w3.org/2018/03/jsonld-wg-charter.html</a>.</p>                
+            </dd>
+
+            <!-- ********************** -->
+            <dt id="yaml-ld-10" class="spec">YAML-LD 1.0</dt>
+            <dd>
+              <p>This document defines YAML-LD, a set of conventions built on top of YAML, which outlines how to serialize Linked Data as YAML based on JSON-LD syntax, semantics, and APIs.</p>
+
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/">YAML-LD</a>, Final Community Group Report (2023-12-06), adopted from the JSON for Linking Data Community Group.</p>
+              <p class="milestone"><b>Expected completion:</b> Q1 2027.</p>
+            </dd>
+
+            <dt id="cbor-ld-10" class="spec">CBOR-LD 1.0</dt>
+            <dd>
+              <p>This specification defines CBOR-LD, a CBOR-based format to serialize Linked Data. The encoding is designed to leverage the existing JSON-LD ecosystem, to provide a compact serialization format for those seeking efficient encoding schemes for Linked Data.</p>
+
+              <p class="draft-status"><b>Draft state:</b> <a href="https://json-ld.github.io/cbor-ld-spec/">CBOR-LD</a>, Community Group Draft Report (2025-05-09), adopted from the JSON for Linking Data Community Group.</p>
+              <p class="milestone"><b>Expected completion:</b> Q1 2027.</p>
+            </dd>
+          </dl>
         </section>
 
         <section id="ig-other-deliverables">
@@ -423,7 +431,7 @@
         </p>
 
         <p>
-          The Chairs should periodically look through the non-Members who have contributed to the Working Group or the JSON for Linking Data Community Group and consider whether each one should be invited to participate as an <a href="https://www.w3.org/invited-experts/">Invited Expert</a>. If a non-Member contributor would like to participate in meetings, they are encouraged to <i class="todo">[update this link] <a href="https://www.w3.org/groups/wg/TODO/instructions/">apply to be an Invited Expert</a></i>.
+          The Chairs should periodically look through the non-Members who have contributed to the Working Group or the JSON for Linking Data Community Group and consider whether each one should be invited to participate as an <a href="https://www.w3.org/invited-experts/">Invited Expert</a>. If a non-Member contributor would like to participate in meetings, they are encouraged to <a href="https://www.w3.org/groups/wg/json-ld/instructions/">apply to be an Invited Expert</a>.
         </p>
 
         <p>Participants in the group are required (by the <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>) to follow the


### PR DESCRIPTION
(I have no idea what happens with all the changes, I presume this is because this repo was forked from a W3C repo. The only file I really changed was 2024/json-ld-wg/index.html....


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/pull/11.html" title="Last updated on Aug 27, 2025, 1:10 PM UTC (9b3607c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/11/d541f3d...9b3607c.html" title="Last updated on Aug 27, 2025, 1:10 PM UTC (9b3607c)">Diff</a>