### PR TITLE
Removing extra sentence referring to CBOR-LD

### DIFF
--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -163,9 +163,7 @@
           JSON-LD's underlying Linked Data structure in other formats. YAML-LD has been created by the
           <a href="https://www.w3.org/community/json-ld/">JSON for Linking Data Community Group</a> for easing human
           authoring and providing a clearer path for using Linked Data applied to popular YAML-based documents such as
-          infrastructure as code, static site front matter, and API documentation formats. Additionally, a need arose
-          in the Verifiable Credentials space for providing a more compressed expression of JSON-LD, and work on
-          CBOR-LD was begun in the JSON-LD CG.
+          infrastructure as code, static site front matter, and API documentation formats.
         </p>
 
         <p>


### PR DESCRIPTION
Forgot to remove the last sentence in the (by now) separate paragraph on CBOR-LD. My mistake, sorry.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/pull/19.html" title="Last updated on Aug 28, 2025, 4:12 AM UTC (7955ba1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/19/d4c87b3...7955ba1.html" title="Last updated on Aug 28, 2025, 4:12 AM UTC (7955ba1)">Diff</a>