### PR TITLE
Remove the "and more" for other formats

### DIFF
--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -200,7 +200,7 @@
 				</p>
         <p>
           The Working Group will also develop new Recommendation Track deliverables, based on work incubated by the <a href="https://www.w3.org/community/json-ld/">JSON for Linking Data Community Group</a>,
-          specifying the use of JSON-LD algorithms with similar formats (YAML, CBOR, and more).
+          specifying the use of JSON-LD algorithms with similar formats (YAML and CBOR).
         </p>
         <p>The Working Group is expected to coordinate with the <a href='https://www.w3.org/community/json-ld/'>JSON for Linking Data Community Group</a> on consensus-based proposals related to content changes for the JSON-LD Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter.</p>
 


### PR DESCRIPTION
Fix json-ld/json-ld-charter-2025#6 : removing the "and more" reference


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/pull/20.html" title="Last updated on Aug 28, 2025, 4:15 AM UTC (e8da96e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/20/d4c87b3...e8da96e.html" title="Last updated on Aug 28, 2025, 4:15 AM UTC (e8da96e)">Diff</a>