### PR TITLE
Remove RDF Dataset Normalization from out of scope list

### DIFF
--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -217,7 +217,6 @@
             <p>The following features are out of scope, and will not be addressed by this Working Group.</p>
 
             <ul class="scope">
-              <li>RDF Dataset Normalization.</li>
               <li>Linked Data Signatures.</li>
               </ul>
         </section>


### PR DESCRIPTION
Per agreement on the WG call (preempting @BigBlueHat's action...)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/pull/22.html" title="Last updated on Aug 29, 2025, 2:12 PM UTC (ed6c15a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/22/a4a06dc...ed6c15a.html" title="Last updated on Aug 29, 2025, 2:12 PM UTC (ed6c15a)">Diff</a>