### PR TITLE
Adding the yaml/cbor organization references to liaisons

### DIFF
--- a/2024/json-ld-wg/index.html
+++ b/2024/json-ld-wg/index.html
@@ -518,6 +518,17 @@
 
           </dl>
         </section>
+        <section>
+          <h3 id="external-coordination">External Organizations</h3>
+          <dl>
+            <dt><a href="https://datatracker.ietf.org/wg/cbor/about/">IETF CBOR Working Group</a></dt>
+            <dd>Coordinating on the CBOR-LD specification.</dd>
+
+            <dt><a href="https://yaml.org/spec/1.2.2/ext/team/">YAML Language Development Team</a></dt>
+            <dd>Coordinating on the YAML-LD specification.</dd>
+          </dl>
+        </section>
+
       </section>
 
       <section class="participation">


### PR DESCRIPTION
The title tells it all.

Fix json-ld/json-ld-charter-2025#5


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/pull/26.html" title="Last updated on Sep 3, 2025, 12:53 PM UTC (268e041)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-wg-charter/26/9512b94...268e041.html" title="Last updated on Sep 3, 2025, 12:53 PM UTC (268e041)">Diff</a>